### PR TITLE
Output of pathContexts task

### DIFF
--- a/astminer-cli/src/main/kotlin/cli/PathContextsExtractor.kt
+++ b/astminer-cli/src/main/kotlin/cli/PathContextsExtractor.kt
@@ -92,9 +92,12 @@ class PathContextsExtractor : CliktCommand() {
         val outputDir = File(outputDirName)
         for (extension in extensions) {
             val miner = PathMiner(PathRetrievalSettings(maxPathHeight, maxPathWidth))
-            val storage = Code2VecPathStorage(outputDirName)
             val parser = getParser(extension)
             val parsedFiles = parser.parseWithExtension(File(projectRoot), extension)
+
+            val outputDirForLanguage = outputDir.resolve(extension)
+            outputDirForLanguage.mkdir()
+            val storage = Code2VecPathStorage(outputDirForLanguage.path)
 
             parsedFiles.forEach { parseResult ->
                 val root = parseResult.root ?: return@forEach
@@ -110,8 +113,6 @@ class PathContextsExtractor : CliktCommand() {
                 }))
             }
 
-            val outputDirForLanguage = outputDir.resolve(extension)
-            outputDirForLanguage.mkdir()
             // Save stored data on disk
             // TODO: implement batches for path context extraction
             storage.save(maxPaths, maxTokens)

--- a/astminer-cli/src/test/kotlin/cli/Code2VecExtractorTest.kt
+++ b/astminer-cli/src/test/kotlin/cli/Code2VecExtractorTest.kt
@@ -2,57 +2,13 @@ package cli
 
 import cli.util.CliArgs
 import cli.util.languagesToString
+import cli.util.verifyPathContextExtraction
 import org.junit.Test
 import java.io.File
-import kotlin.test.assertTrue
 
 internal class Code2VecExtractorTest {
     private val testDataDir = File("src/test/resources")
     private val code2VecExtractor = Code2VecExtractor()
-
-    /**
-     * Directory with extracted data should contain a directory for each specified language
-     */
-    private fun checkExtractedDir(extractedDataDir: File, languages: List<String>) {
-        val metLanguages = mutableSetOf<String>()
-        extractedDataDir.listFiles()?.forEach { file ->
-            with(file) {
-                assertTrue(isDirectory, "Extracted data directory should not contain file $name")
-                assertTrue(languages.contains(file.name), "Unexpected directory $name")
-                metLanguages.add(name)
-            }
-        }
-        languages.forEach { language ->
-            assertTrue(metLanguages.contains(language), "Did not find directory for $language")
-        }
-    }
-
-    private fun validPathContextsFile(name: String, batching: Boolean): Boolean {
-        return if (batching) {
-            name.startsWith("path_contexts_") && name.endsWith(".csv")
-        } else {
-            name == "path_contexts.csv"
-        }
-    }
-
-    private fun checkLanguageDir(languageDir: File, batching: Boolean) {
-        val expectedFiles = listOf("tokens.csv", "paths.csv", "node_types.csv")
-        languageDir.listFiles()?.forEach { file ->
-            with(file) {
-                assertTrue(
-                    expectedFiles.contains(name) || validPathContextsFile(name, batching),
-                    "Unexpected file $name in ${languageDir.name}"
-                )
-            }
-        }
-    }
-
-    private fun verifyParsingResult(extractedDataDir: File, languages: List<String>, batching: Boolean) {
-        checkExtractedDir(extractedDataDir, languages)
-        languages.forEach { language ->
-            checkLanguageDir(extractedDataDir.resolve(language), batching)
-        }
-    }
 
     @Test
     fun testDefaultExtraction() {
@@ -63,7 +19,7 @@ internal class Code2VecExtractorTest {
             .build()
 
         code2VecExtractor.main(cliArgs.args)
-        verifyParsingResult(extractedDataDir, languages, true)
+        verifyPathContextExtraction(extractedDataDir, languages, true)
     }
 }
 

--- a/astminer-cli/src/test/kotlin/cli/PathContextsExtractorTest.kt
+++ b/astminer-cli/src/test/kotlin/cli/PathContextsExtractorTest.kt
@@ -1,0 +1,24 @@
+package cli
+
+import cli.util.CliArgs
+import cli.util.languagesToString
+import cli.util.verifyPathContextExtraction
+import org.junit.Test
+import java.io.File
+
+internal class PathContextsExtractorTest {
+    private val testDataDir = File("src/test/resources")
+    private val pathContextsExtractor = PathContextsExtractor()
+
+    @Test
+    fun testDefaultExtraction() {
+        val extractedDataDir = createTempDir("extractedData")
+        val languages = listOf("java", "py")
+        val cliArgs = CliArgs.Builder(testDataDir, extractedDataDir)
+            .extensions(languagesToString(languages))
+            .build()
+
+        pathContextsExtractor.main(cliArgs.args)
+        verifyPathContextExtraction(extractedDataDir, languages, true)
+    }
+}

--- a/astminer-cli/src/test/kotlin/cli/util/OutputVerification.kt
+++ b/astminer-cli/src/test/kotlin/cli/util/OutputVerification.kt
@@ -1,0 +1,48 @@
+package cli.util
+
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Directory with extracted data should contain a directory for each specified language
+ */
+internal fun checkExtractedDir(extractedDataDir: File, languages: List<String>) {
+    val metLanguages = mutableSetOf<String>()
+    extractedDataDir.listFiles()?.forEach { file ->
+        with(file) {
+            assertTrue(isDirectory, "Extracted data directory should not contain file $name")
+            assertTrue(languages.contains(file.name), "Unexpected directory $name")
+            metLanguages.add(name)
+        }
+    }
+    languages.forEach { language ->
+        assertTrue(metLanguages.contains(language), "Did not find directory for $language")
+    }
+}
+
+internal fun validPathContextsFile(name: String, batching: Boolean): Boolean {
+    return if (batching) {
+        name.startsWith("path_contexts_") && name.endsWith(".csv")
+    } else {
+        name == "path_contexts.csv"
+    }
+}
+
+internal fun checkPathContextsDir(languageDir: File, batching: Boolean) {
+    val expectedFiles = listOf("tokens.csv", "paths.csv", "node_types.csv")
+    languageDir.listFiles()?.forEach { file ->
+        with(file) {
+            assertTrue(
+                expectedFiles.contains(name) || validPathContextsFile(name, batching),
+                "Unexpected file $name in ${languageDir.name}"
+            )
+        }
+    }
+}
+
+internal fun verifyPathContextExtraction(extractedDataDir: File, languages: List<String>, batching: Boolean) {
+    checkExtractedDir(extractedDataDir, languages)
+    languages.forEach { language ->
+        checkPathContextsDir(extractedDataDir.resolve(language), batching)
+    }
+}


### PR DESCRIPTION
Fix the output issue mentioned in #50, this time for `pathContexts` task.