### PR TITLE
Update GumTree method splitting

### DIFF
--- a/astminer-cli/build.gradle.kts
+++ b/astminer-cli/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compile("io.github.vovak.astminer", "astminer", "0.5")
+    compile("io.github.vovak.astminer", "astminer-dev", "0.5.4")
     compile("com.github.ajalt", "clikt", "2.1.0")
 
     testImplementation("junit:junit:4.11")

--- a/astminer-cli/src/main/kotlin/cli/Code2VecExtractor.kt
+++ b/astminer-cli/src/main/kotlin/cli/Code2VecExtractor.kt
@@ -5,12 +5,12 @@ import astminer.common.model.*
 import astminer.common.preOrder
 import astminer.common.setNormalizedToken
 import astminer.common.splitToSubtokens
-import astminer.parse.antlr.java.JavaMethodSplitter
-import astminer.parse.antlr.java.JavaParser
 import astminer.parse.antlr.python.PythonMethodSplitter
 import astminer.parse.antlr.python.PythonParser
 import astminer.parse.cpp.FuzzyCppParser
 import astminer.parse.cpp.FuzzyMethodSplitter
+import astminer.parse.java.GumTreeJavaParser
+import astminer.parse.java.GumTreeMethodSplitter
 import astminer.paths.Code2VecPathStorage
 import astminer.paths.PathMiner
 import astminer.paths.PathRetrievalSettings
@@ -111,9 +111,9 @@ class Code2VecExtractor : CliktCommand() {
                     extractFromMethods(roots, FuzzyMethodSplitter(), miner, storage)
                 }
                 "java" -> {
-                    val parser = JavaParser()
+                    val parser = GumTreeJavaParser()
                     val roots = parser.parseWithExtension(File(projectRoot), extension)
-                    extractFromMethods(roots, JavaMethodSplitter(), miner, storage)
+                    extractFromMethods(roots, GumTreeMethodSplitter(), miner, storage)
                 }
                 "py" -> {
                     val parser = PythonParser()

--- a/astminer-cli/src/main/kotlin/cli/Granularity.kt
+++ b/astminer-cli/src/main/kotlin/cli/Granularity.kt
@@ -5,10 +5,11 @@ import astminer.common.model.MethodInfo
 import astminer.common.model.Node
 import astminer.common.model.ParseResult
 import astminer.parse.antlr.SimpleNode
-import astminer.parse.antlr.java.JavaMethodSplitter
 import astminer.parse.antlr.python.PythonMethodSplitter
 import astminer.parse.cpp.FuzzyMethodSplitter
 import astminer.parse.cpp.FuzzyNode
+import astminer.parse.java.GumTreeJavaNode
+import astminer.parse.java.GumTreeMethodSplitter
 
 
 interface Granularity {
@@ -37,8 +38,8 @@ class MethodGranularity(override val splitTokens: Boolean,
                 filteredParseResults.map { it.root as FuzzyNode }.flatMap { methodSplitter.splitIntoMethods(it) }
             }
             "java" -> {
-                val methodSplitter = JavaMethodSplitter()
-                filteredParseResults.map { it.root as SimpleNode }.flatMap { methodSplitter.splitIntoMethods(it) }
+                val methodSplitter = GumTreeMethodSplitter()
+                filteredParseResults.map { it.root as GumTreeJavaNode }.flatMap { methodSplitter.splitIntoMethods(it) }
             }
             "py" -> {
                 val methodSplitter = PythonMethodSplitter()

--- a/astminer-cli/src/main/kotlin/cli/PathContextsExtractor.kt
+++ b/astminer-cli/src/main/kotlin/cli/PathContextsExtractor.kt
@@ -4,9 +4,9 @@ import astminer.common.getNormalizedToken
 import astminer.common.model.*
 import astminer.common.preOrder
 import astminer.common.setNormalizedToken
-import astminer.parse.antlr.java.JavaParser
 import astminer.parse.antlr.python.PythonParser
 import astminer.parse.cpp.FuzzyCppParser
+import astminer.parse.java.GumTreeJavaParser
 import astminer.paths.Code2VecPathStorage
 import astminer.paths.PathMiner
 import astminer.paths.PathRetrievalSettings
@@ -32,7 +32,7 @@ class PathContextsExtractor : CliktCommand() {
      * List of supported language extensions and corresponding parsers.
      */
     private val supportedLanguages = listOf(
-        SupportedLanguage(JavaParser(), "java"),
+        SupportedLanguage(GumTreeJavaParser(), "java"),
         SupportedLanguage(FuzzyCppParser(), "c"),
         SupportedLanguage(FuzzyCppParser(), "cpp"),
         SupportedLanguage(PythonParser(), "py")

--- a/astminer-cli/src/main/kotlin/cli/ProjectParser.kt
+++ b/astminer-cli/src/main/kotlin/cli/ProjectParser.kt
@@ -5,9 +5,9 @@ import astminer.ast.DotAstStorage
 import astminer.common.model.AstStorage
 import astminer.common.model.Node
 import astminer.common.model.Parser
-import astminer.parse.antlr.java.JavaParser
 import astminer.parse.antlr.python.PythonParser
 import astminer.parse.cpp.FuzzyCppParser
+import astminer.parse.java.GumTreeJavaParser
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -41,7 +41,7 @@ class ProjectParser : CliktCommand() {
      * List of supported language extensions and corresponding parsers.
      */
     private val supportedLanguages = listOf(
-        SupportedLanguage(JavaParser(), "java"),
+        SupportedLanguage(GumTreeJavaParser(), "java"),
         SupportedLanguage(FuzzyCppParser(), "c"),
         SupportedLanguage(FuzzyCppParser(), "cpp"),
         SupportedLanguage(PythonParser(), "py")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import tanvd.kosogor.proxy.publishJar
 
 group = "io.github.vovak.astminer"
-version = "0.5"
+version = "0.5.4"
 
 plugins {
     id("java")
@@ -97,7 +97,7 @@ idea {
 
 publishJar {
     publication {
-        artifactId = "astminer"
+        artifactId = "astminer-dev"
     }
 
     bintray {

--- a/src/main/kotlin/astminer/common/model/TreeSplittingModel.kt
+++ b/src/main/kotlin/astminer/common/model/TreeSplittingModel.kt
@@ -1,10 +1,5 @@
 package astminer.common.model
 
-
-interface TreeSplitter<T : Node> {
-    fun split(root: T): Collection<T>
-}
-
 interface TreeMethodSplitter<T : Node> {
     fun splitIntoMethods(root: T): Collection<MethodInfo<T>>
 }

--- a/src/main/kotlin/astminer/examples/AllJavaMethods.kt
+++ b/src/main/kotlin/astminer/examples/AllJavaMethods.kt
@@ -1,10 +1,10 @@
 package astminer.examples
 
 import astminer.common.model.LabeledPathContexts
+import astminer.common.model.MethodInfo
+import astminer.parse.java.GumTreeJavaNode
 import astminer.parse.java.GumTreeJavaParser
 import astminer.parse.java.GumTreeMethodSplitter
-import astminer.parse.java.MethodInfo
-import astminer.parse.java.getMethodInfo
 import astminer.paths.PathMiner
 import astminer.paths.PathRetrievalSettings
 import astminer.paths.CsvPathStorage
@@ -12,9 +12,11 @@ import astminer.paths.toPathContext
 import java.io.File
 
 
-private fun getCsvFriendlyMethodId(methodInfo: MethodInfo?): String {
-    if (methodInfo == null) return "unknown_method"
-    return "${methodInfo.enclosingClassName}.${methodInfo.methodName}(${methodInfo.parameterTypes.joinToString("|")})"
+private fun getCsvFriendlyMethodId(methodInfo: MethodInfo<GumTreeJavaNode>): String {
+    val className = methodInfo.enclosingElement.name() ?: ""
+    val methodName = methodInfo.method.name() ?: "unknown_method"
+    val parameterTypes = methodInfo.methodParameters.map { it.name() ?: "_" }.joinToString("|")
+    return "$className.$methodName($parameterTypes)"
 }
 
 
@@ -32,13 +34,13 @@ fun allJavaMethods() {
         val fileNode = GumTreeJavaParser().parse(file.inputStream()) ?: return@forFilesWithSuffix
 
         //extract method nodes
-        val methodNodes = GumTreeMethodSplitter().split(fileNode)
+        val methodNodes = GumTreeMethodSplitter().splitIntoMethods(fileNode)
 
-        methodNodes.forEach { methodNode ->
+        methodNodes.forEach { methodInfo ->
             //Retrieve paths from every node individually
-            val paths = miner.retrievePaths(methodNode)
+            val paths = miner.retrievePaths(methodInfo.method.root)
             //Retrieve a method identifier
-            val entityId = "${file.path}::${getCsvFriendlyMethodId(methodNode.getMethodInfo())}"
+            val entityId = "${file.path}::${getCsvFriendlyMethodId(methodInfo)}"
             storage.store(LabeledPathContexts(entityId, paths.map { toPathContext(it) }))
         }
     }

--- a/src/main/kotlin/astminer/examples/AllJavaMethods.kt
+++ b/src/main/kotlin/astminer/examples/AllJavaMethods.kt
@@ -13,9 +13,9 @@ import java.io.File
 
 
 private fun getCsvFriendlyMethodId(methodInfo: MethodInfo<GumTreeJavaNode>): String {
-    val className = methodInfo.enclosingElement.name() ?: ""
-    val methodName = methodInfo.method.name() ?: "unknown_method"
-    val parameterTypes = methodInfo.methodParameters.map { it.name() ?: "_" }.joinToString("|")
+    val className = methodInfo.enclosingElementName() ?: ""
+    val methodName = methodInfo.name() ?: "unknown_method"
+    val parameterTypes = methodInfo.methodParameters.joinToString("|") { it.name() ?: "_" }
     return "$className.$methodName($parameterTypes)"
 }
 

--- a/src/main/kotlin/astminer/examples/Code2VecJavaMethods.kt
+++ b/src/main/kotlin/astminer/examples/Code2VecJavaMethods.kt
@@ -4,15 +4,8 @@ import astminer.common.*
 import astminer.common.model.LabeledPathContexts
 import astminer.parse.antlr.java.JavaMethodSplitter
 import astminer.parse.antlr.java.JavaParser
-import astminer.parse.java.MethodInfo
 import astminer.paths.*
 import java.io.File
-
-
-private fun getCsvFriendlyMethodId(methodInfo: MethodInfo?): String {
-    if (methodInfo == null) return "unknown_method"
-    return "${methodInfo.enclosingClassName}.${methodInfo.methodName}(${methodInfo.parameterTypes.joinToString("|")})"
-}
 
 
 //Retrieve paths from all Java files, using a GumTree parser.

--- a/src/test/kotlin/astminer/parse/java/GumTreeMethodSplitterTest.kt
+++ b/src/test/kotlin/astminer/parse/java/GumTreeMethodSplitterTest.kt
@@ -1,49 +1,81 @@
 package astminer.parse.java
 
-import org.junit.Assert
+import astminer.common.model.MethodInfo
 import org.junit.Test
 import java.io.File
+import kotlin.test.assertEquals
 
 private fun createTree(filename: String): GumTreeJavaNode {
     val parser = GumTreeJavaParser()
     return parser.parse(File(filename).inputStream()) as GumTreeJavaNode
 }
 
-private fun createAndSplitTree(filename: String): Collection<GumTreeJavaNode> {
-    return GumTreeMethodSplitter().split(createTree(filename))
+private fun createAndSplitTree(filename: String): Collection<MethodInfo<GumTreeJavaNode>> {
+    return GumTreeMethodSplitter().splitIntoMethods(createTree(filename))
 }
 
 class GumTreeMethodSplitterTest {
     @Test
     fun testMethodExtraction1() {
-        val methodNodes = createAndSplitTree("testData/gumTreeMethodSplitter/1.java")
+        val methodInfos = createAndSplitTree("testData/gumTreeMethodSplitter/1.java")
 
-        Assert.assertEquals(1, methodNodes.size)
-        Assert.assertEquals(MethodInfo("SingleFunction", "fun", listOf("String[]", "int")), methodNodes.first().getMethodInfo())
+        assertEquals(1, methodInfos.size)
+        with(methodInfos.first()) {
+            assertEquals("fun", name())
+            assertEquals("void", returnType())
+            assertEquals("SingleFunction", enclosingElementName())
+            assertEquals(listOf("args", "param"), methodParameters.map { it.name() }.toList())
+            assertEquals(listOf("String[]", "int"), methodParameters.map { it.returnType() }.toList())
+        }
+
     }
 
     @Test
     fun testMethodExtraction2() {
-        val methodNodes = createAndSplitTree("testData/gumTreeMethodSplitter/2.java")
+        val methodInfos = createAndSplitTree("testData/gumTreeMethodSplitter/2.java")
 
-        Assert.assertEquals(1, methodNodes.size)
-        Assert.assertEquals(MethodInfo("InnerClass", "main", listOf("String[]")), methodNodes.first().getMethodInfo())
+        assertEquals(1, methodInfos.size)
+        with(methodInfos.first()) {
+            assertEquals("main", name())
+            assertEquals("void", returnType())
+            assertEquals("InnerClass", enclosingElementName())
+            assertEquals(listOf("args"), methodParameters.map { it.name() }.toList())
+            assertEquals(listOf("String[]"), methodParameters.map { it.returnType() }.toList())
+        }
     }
 
     @Test
     fun testMethodExtraction3() {
-        val methodNodes = createAndSplitTree("testData/gumTreeMethodSplitter/3.java")
+        val methodInfos = createAndSplitTree("testData/gumTreeMethodSplitter/3.java")
 
-        Assert.assertEquals(2, methodNodes.size)
-        Assert.assertTrue(methodNodes.map { it.getMethodInfo() }.contains(MethodInfo("InnerClass","main", listOf("String[]"))))
-        Assert.assertTrue(methodNodes.map { it.getMethodInfo() }.contains(MethodInfo("SingleMethodInnerClass", "fun", listOf("String[]", "int"))))
+        assertEquals(2, methodInfos.size)
+        with(methodInfos.first()) {
+            assertEquals("main", name())
+            assertEquals("void", returnType())
+            assertEquals("InnerClass", enclosingElementName())
+            assertEquals(listOf("args"), methodParameters.map { it.name() }.toList())
+            assertEquals(listOf("String[]"), methodParameters.map { it.returnType() }.toList())
+        }
+        with(methodInfos.last()) {
+            assertEquals("fun", name())
+            assertEquals("void", returnType())
+            assertEquals("SingleMethodInnerClass", enclosingElementName())
+            assertEquals(listOf("args", "param"), methodParameters.map { it.name() }.toList())
+            assertEquals(listOf("String[]", "int"), methodParameters.map { it.returnType() }.toList())
+        }
     }
 
     @Test
     fun testMethodExtraction4() {
-        val methodNodes = createAndSplitTree("testData/gumTreeMethodSplitter/4.java")
+        val methodInfos = createAndSplitTree("testData/gumTreeMethodSplitter/4.java")
 
-        Assert.assertEquals(1, methodNodes.size)
-        Assert.assertEquals(MethodInfo("SingleFunction", "fun", listOf("int", "int")), methodNodes.first().getMethodInfo())
+        assertEquals(1, methodInfos.size)
+        with(methodInfos.first()) {
+            assertEquals("fun", name())
+            assertEquals("int", returnType())
+            assertEquals("SingleFunction", enclosingElementName())
+            assertEquals(listOf("args", "param"), methodParameters.map { it.name() }.toList())
+            assertEquals(listOf("int", "SingleFunction"), methodParameters.map { it.returnType() }.toList())
+        }
     }
 }

--- a/testData/gumTreeMethodSplitter/4.java
+++ b/testData/gumTreeMethodSplitter/4.java
@@ -1,5 +1,6 @@
 class SingleFunction {
-    void fun(int args, int param) {
+    int fun(int args, SingleFunction param) {
         System.out.println("Hello again world!");
+        return 0;
     }
 }


### PR DESCRIPTION
Method splitting with GumTree had a different interface compared to other parsers. This PR fixes this issue in order to use GumTree in CLI (instead of ANTLR-based parser).