### PR TITLE
Add option to override storage parameters

### DIFF
--- a/astminer-cli/build.gradle.kts
+++ b/astminer-cli/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compile("io.github.vovak.astminer", "astminer-dev", "0.5.4")
+    compile("io.github.vovak.astminer", "astminer-dev", "0.5.5")
     compile("com.github.ajalt", "clikt", "2.1.0")
 
     testImplementation("junit:junit:4.11")

--- a/astminer-cli/src/test/kotlin/cli/Code2VecExtractorTest.kt
+++ b/astminer-cli/src/test/kotlin/cli/Code2VecExtractorTest.kt
@@ -19,7 +19,7 @@ internal class Code2VecExtractorTest {
             .build()
 
         code2VecExtractor.main(cliArgs.args)
-        verifyPathContextExtraction(extractedDataDir, languages, true)
+        verifyPathContextExtraction(extractedDataDir, languages, false)
     }
 }
 

--- a/astminer-cli/src/test/kotlin/cli/PathContextsExtractorTest.kt
+++ b/astminer-cli/src/test/kotlin/cli/PathContextsExtractorTest.kt
@@ -19,6 +19,6 @@ internal class PathContextsExtractorTest {
             .build()
 
         pathContextsExtractor.main(cliArgs.args)
-        verifyPathContextExtraction(extractedDataDir, languages, true)
+        verifyPathContextExtraction(extractedDataDir, languages, false)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import tanvd.kosogor.proxy.publishJar
 
 group = "io.github.vovak.astminer"
-version = "0.5.4"
+version = "0.5.5"
 
 plugins {
     id("java")

--- a/src/main/java/astminer/examples/AllJavaFiles.java
+++ b/src/main/java/astminer/examples/AllJavaFiles.java
@@ -18,7 +18,7 @@ public class AllJavaFiles {
 
     public static void runExample() {
         final PathMiner miner = new PathMiner(new PathRetrievalSettings(5,5));
-        final CountingPathStorage<String> pathStorage = new CsvPathStorage(OUTPUT_FOLDER);
+        final CountingPathStorage<String> pathStorage = new CsvPathStorage(OUTPUT_FOLDER, false, 0);
 
         final Path inputFolder = Paths.get(INPUT_FOLDER);
 

--- a/src/main/kotlin/astminer/paths/Code2VecPathStorage.kt
+++ b/src/main/kotlin/astminer/paths/Code2VecPathStorage.kt
@@ -3,7 +3,11 @@ package astminer.paths
 import astminer.common.storage.*
 import java.io.File
 
-class Code2VecPathStorage(outputFolderPath: String) : CountingPathStorage<String>(outputFolderPath) {
+class Code2VecPathStorage(
+        outputFolderPath: String,
+        batchMode: Boolean = true,
+        fragmentsPerBatch: Long = DEFAULT_FRAGMENTS_PER_BATCH
+) : CountingPathStorage<String>(outputFolderPath, batchMode, fragmentsPerBatch) {
 
     override fun dumpPathContexts(file: File, tokensLimit: Long, pathsLimit: Long) {
         val lines = mutableListOf<String>()

--- a/src/main/kotlin/astminer/paths/CsvPathStorage.kt
+++ b/src/main/kotlin/astminer/paths/CsvPathStorage.kt
@@ -3,7 +3,11 @@ package astminer.paths
 import astminer.common.storage.writeLinesToFile
 import java.io.File
 
-class CsvPathStorage(directoryPath: String) : CountingPathStorage<String>(directoryPath) {
+class CsvPathStorage(
+        outputFolderPath: String,
+        batchMode: Boolean = true,
+        fragmentsPerBatch: Long = DEFAULT_FRAGMENTS_PER_BATCH
+) : CountingPathStorage<String>(outputFolderPath, batchMode, fragmentsPerBatch) {
 
     override fun dumpPathContexts(file: File, tokensLimit: Long, pathsLimit: Long) {
         val lines = mutableListOf("label,path_contexts")


### PR DESCRIPTION
Added options to toggle batching mode in CLI. Now parameters `maxToken` and `maxPaths` work as intended.
P.S.: I know that `Code2VecExtractor` and `PathContextsExtractor` are ugly duplicates. I'm working on their unified version with granularity support in another branch.