### PR TITLE
remove commas and other symbols from filepath

### DIFF
--- a/src/main/kotlin/astminer/ast/DotAstStorage.kt
+++ b/src/main/kotlin/astminer/ast/DotAstStorage.kt
@@ -67,7 +67,7 @@ class DotAstStorage : AstStorage {
 
     // Label should contain only latin letters and underscores, other symbols replace with an underscore
     internal fun normalizeAstLabel(label: String): String =
-            label.replace("[^A-z,^_]".toRegex(), "_")
+            label.replace("[^A-z^_]".toRegex(), "_")
 
     /**
      * Filepath should contain only latin letters, underscores, hyphens, backslashes and dots

--- a/src/main/kotlin/astminer/ast/DotAstStorage.kt
+++ b/src/main/kotlin/astminer/ast/DotAstStorage.kt
@@ -36,8 +36,9 @@ class DotAstStorage : AstStorage {
             // TODO: save full signature for method
             val (sourceFile, label) = splitFullPath(fullPath)
             val normalizedLabel = normalizeAstLabel(label)
+            val normalizedFilepath = normalizeFilepath(sourceFile)
             val nodesMap = dumpAst(root, File(astDirectoryPath, astFilenameFormat.format(index)), normalizedLabel)
-            val nodeDescriptionFormat = "${astFilenameFormat.format(index)},$sourceFile,$label,%d,%s,%s"
+            val nodeDescriptionFormat = "${astFilenameFormat.format(index)},$normalizedFilepath,$label,%d,%s,%s"
             for (node in root.preOrder()) {
                 descriptionLines.add(
                         nodeDescriptionFormat.format(nodesMap.getId(node) - 1, node.getNormalizedToken(), node.getTypeLabel())
@@ -67,6 +68,13 @@ class DotAstStorage : AstStorage {
     // Label should contain only latin letters and underscores, other symbols replace with an underscore
     internal fun normalizeAstLabel(label: String): String =
             label.replace("[^A-z,^_]".toRegex(), "_")
+
+    /**
+     * Filepath should contain only latin letters, underscores, hyphens, backslashes and dots
+     * Underscore replace other symbols
+     */
+    internal fun normalizeFilepath(filepath: String): String =
+            filepath.replace("[^A-z^_^\\-^.^/]".toRegex(), "_")
 
     /**
      * Split the full path to specified file into the parent's path, and the file name

--- a/src/test/kotlin/astminer/ast/DotAstStorageTest.kt
+++ b/src/test/kotlin/astminer/ast/DotAstStorageTest.kt
@@ -67,4 +67,14 @@ class DotAstStorageTest {
         assertEquals("", path)
         assertEquals("file.name", fileName)
     }
+
+    @Test
+    fun testFilepathNormalization() {
+        // real life example
+        val badFilepath = "interviews/Leet-Code/binary-search/pow(x,n).java"
+        val storage = DotAstStorage()
+        val normalizedFilepath = storage.normalizeFilepath(badFilepath)
+
+        assertEquals("interviews/Leet-Code/binary-search/pow_x_n_.java", normalizedFilepath)
+    }
 }

--- a/src/test/kotlin/astminer/ast/DotAstStorageTest.kt
+++ b/src/test/kotlin/astminer/ast/DotAstStorageTest.kt
@@ -49,6 +49,15 @@ class DotAstStorageTest {
     }
 
     @Test
+    fun testLabelWithCommaNormalization() {
+        val labelWithComma = "some,bad,label"
+        val storage = DotAstStorage()
+        val normalizedLabel = storage.normalizeAstLabel(labelWithComma)
+
+        assertEquals("some_bad_label", normalizedLabel)
+    }
+
+    @Test
     fun testSplittingFullPath() {
         val fullPath = "/path1/path2/path_3/path.4/file.name"
         val storage = DotAstStorage()


### PR DESCRIPTION
We should do this because commas in the file path or file name will break CSV file