### PR TITLE
rename graph in dot storage

### DIFF
--- a/astminer-cli/src/main/kotlin/cli/Granularity.kt
+++ b/astminer-cli/src/main/kotlin/cli/Granularity.kt
@@ -61,8 +61,10 @@ class MethodGranularity(override val splitTokens: Boolean,
                             FileMethods(methodSplitter.splitIntoMethods(it.root as SimpleNode), it.filePath)
                         }
                     }
+                    else -> {
+                        throw UnsupportedOperationException("Unsupported parser $javaParser")
+                    }
                 }
-                throw UnsupportedOperationException("Unsupported parser $javaParser")
             }
             "py" -> {
                 val methodSplitter = PythonMethodSplitter()

--- a/astminer-cli/src/main/kotlin/cli/ProjectParser.kt
+++ b/astminer-cli/src/main/kotlin/cli/ProjectParser.kt
@@ -118,8 +118,10 @@ class ProjectParser : CliktCommand() {
                 when (javaParser) {
                     "gumtree" -> GumTreeJavaParser()
                     "antlr" -> JavaParser()
+                    else -> {
+                        throw UnsupportedOperationException("Unsupported parser for java extension $javaParser")
+                    }
                 }
-                throw UnsupportedOperationException("Unsupported parser for java extension $javaParser")
             }
             else -> {
                 supportedLanguages.find { it.extension == extension }?.parser

--- a/src/main/kotlin/astminer/ast/DotAstStorage.kt
+++ b/src/main/kotlin/astminer/ast/DotAstStorage.kt
@@ -51,7 +51,7 @@ class DotAstStorage : AstStorage {
     private fun dumpAst(root: Node, file: File, astName: String) : RankedIncrementalIdStorage<Node> {
         val nodesMap = RankedIncrementalIdStorage<Node>()
         // dot parsers (e.g. pydot) can't parse graph/digraph if its name is "graph"
-        val fixedAstName = if (astName == "graph") "_$astName" else astName
+        val fixedAstName = if (astName == "graph" || astName == "digraph") "_$astName" else astName
         val astLines = mutableListOf("digraph $fixedAstName {")
 
         for (node in root.preOrder()) {

--- a/src/main/kotlin/astminer/ast/DotAstStorage.kt
+++ b/src/main/kotlin/astminer/ast/DotAstStorage.kt
@@ -50,7 +50,9 @@ class DotAstStorage : AstStorage {
 
     private fun dumpAst(root: Node, file: File, astName: String) : RankedIncrementalIdStorage<Node> {
         val nodesMap = RankedIncrementalIdStorage<Node>()
-        val astLines = mutableListOf("digraph $astName {")
+        // dot parsers (e.g. pydot) can't parse graph/digraph if its name is "graph"
+        val fixedAstName = if (astName == "graph") "_$astName" else astName
+        val astLines = mutableListOf("digraph $fixedAstName {")
 
         for (node in root.preOrder()) {
             val rootId = nodesMap.record(node) - 1


### PR DESCRIPTION
For graphs, like:
```
graph graph {
...
}
```
pydot returns 2 graphs: empty and original, so such graphs are renamed to `_graph`.
