### PR TITLE
Fix path retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ java -jar cli.jar parse --lang py,java,c,cpp --project path/to/project --output 
 
 Extract path contexts from all the files in supported languages and store in form `fileName triplesOfPathContexts`.
 ```shell script
-java -jar cli.jar pathContexts --lang py,java,c,cpp --project path/to/project --output path/to/results --maxH H --maxW W --maxContexts C --maxTokens T --maxPaths P
+java -jar cli.jar pathContexts --lang py,java,c,cpp --project path/to/project --output path/to/results --maxL L --maxW W --maxContexts C --maxTokens T --maxPaths P
 ```
 
 #### Code2vec
@@ -85,7 +85,7 @@ java -jar cli.jar pathContexts --lang py,java,c,cpp --project path/to/project --
 Extract data suitable as input for [code2vec](https://github.com/tech-srl/code2vec) model.
 Parse all files written in specified language into ASTs, split into methods, and store in form `method|name triplesOfPathContexts`.
 ```shell script
-java -jar cli.jar code2vec --lang py,java,c,cpp --project path/to/project --output path/to/results --maxH H --maxW W --maxContexts C --maxTokens T --maxPaths P
+java -jar cli.jar code2vec --lang py,java,c,cpp --project path/to/project --output path/to/results --maxL L --maxW W --maxContexts C --maxTokens T --maxPaths P
 ```
 
 ### Integrate in your mining pipeline

--- a/src/main/kotlin/astminer/cli/Code2VecExtractor.kt
+++ b/src/main/kotlin/astminer/cli/Code2VecExtractor.kt
@@ -34,9 +34,9 @@ class Code2VecExtractor(private val customLabelExtractor: LabelExtractor? = null
         help = "Path to directory where the output will be stored"
     ).required()
 
-    val maxPathHeight: Int by option(
-        "--maxH",
-        help = "Maximum height of path for code2vec"
+    val maxPathLength: Int by option(
+        "--maxL",
+        help = "Maximum length of path for code2vec"
     ).int().default(8)
 
     val maxPathWidth: Int by option(
@@ -142,7 +142,7 @@ class Code2VecExtractor(private val customLabelExtractor: LabelExtractor? = null
     private fun extract(labelExtractor: LabelExtractor) {
         val outputDir = File(outputDirName)
         for (extension in extensions) {
-            val miner = PathMiner(PathRetrievalSettings(maxPathHeight, maxPathWidth))
+            val miner = PathMiner(PathRetrievalSettings(maxPathLength, maxPathWidth))
 
             val outputDirForLanguage = outputDir.resolve(extension)
             outputDirForLanguage.mkdir()

--- a/src/main/kotlin/astminer/cli/PathContextsExtractor.kt
+++ b/src/main/kotlin/astminer/cli/PathContextsExtractor.kt
@@ -50,9 +50,9 @@ class PathContextsExtractor(private val customLabelExtractor: LabelExtractor? = 
             help = "Path to directory where the output will be stored"
     ).required()
 
-    val maxPathHeight: Int by option(
-            "--maxH",
-            help = "Maximum height of path for code2vec"
+    val maxPathLength: Int by option(
+            "--maxL",
+            help = "Maximum length of path for code2vec"
     ).int().default(8)
 
     val maxPathWidth: Int by option(
@@ -101,7 +101,7 @@ class PathContextsExtractor(private val customLabelExtractor: LabelExtractor? = 
     private fun extractPathContexts(labelExtractor: LabelExtractor) {
         val outputDir = File(outputDirName)
         for (extension in extensions) {
-            val miner = PathMiner(PathRetrievalSettings(maxPathHeight, maxPathWidth))
+            val miner = PathMiner(PathRetrievalSettings(maxPathLength, maxPathWidth))
             val parser = getParser(extension)
 
             val parsedFiles = parser.parseWithExtension(File(projectRoot), extension)

--- a/src/main/kotlin/astminer/common/model/PathContextsModel.kt
+++ b/src/main/kotlin/astminer/common/model/PathContextsModel.kt
@@ -14,3 +14,5 @@ data class PathContextId(val startTokenId: Long, val pathId: Long, val endTokenI
 data class LabeledPathContexts<T>(val label: T, val pathContexts: Collection<PathContext>)
 
 data class LabeledPathContextIds<T>(val label: T, val pathContexts: Collection<PathContextId>)
+
+typealias PathPiece = List<Node>

--- a/src/main/kotlin/astminer/common/model/PathContextsModel.kt
+++ b/src/main/kotlin/astminer/common/model/PathContextsModel.kt
@@ -1,9 +1,9 @@
 package astminer.common.model
 
 
-data class ASTPath(val upwardNodes: List<Node>, val downwardNodes: List<Node>)
+data class ASTPath(val upwardNodes: List<Node>, val topNode: Node, val downwardNodes: List<Node>)
 
-enum class Direction { UP, DOWN }
+enum class Direction { UP, DOWN, TOP }
 
 data class OrientedNodeType(val typeLabel: String, val direction: Direction)
 

--- a/src/main/kotlin/astminer/paths/PathMiner.kt
+++ b/src/main/kotlin/astminer/paths/PathMiner.kt
@@ -3,12 +3,12 @@ package astminer.paths
 import astminer.common.model.ASTPath
 import astminer.common.model.Node
 
-data class PathRetrievalSettings(val maxHeight: Int, val maxWidth: Int)
+data class PathRetrievalSettings(val maxLength: Int, val maxWidth: Int)
 
 class PathMiner(val settings: PathRetrievalSettings) {
     private val pathWorker = PathWorker()
 
     fun retrievePaths(tree: Node): Collection<ASTPath> {
-        return pathWorker.retrievePaths(tree, settings.maxHeight, settings.maxWidth)
+        return pathWorker.retrievePaths(tree, settings.maxLength, settings.maxWidth)
     }
 }

--- a/src/main/kotlin/astminer/paths/PathUtil.kt
+++ b/src/main/kotlin/astminer/paths/PathUtil.kt
@@ -2,10 +2,13 @@ package astminer.paths
 
 import astminer.common.model.*
 
-fun toPathContext(path: ASTPath, getToken: (Node) -> String = { node -> node.getToken()}): PathContext {
+typealias PathPiece = List<Node>
+
+fun toPathContext(path: ASTPath, getToken: (Node) -> String = { node -> node.getToken() }): PathContext {
     val startToken = getToken(path.upwardNodes.first())
     val endToken = getToken(path.downwardNodes.last())
     val astNodes = path.upwardNodes.map { OrientedNodeType(it.getTypeLabel(), Direction.UP) } +
+            OrientedNodeType(path.topNode.getTypeLabel(), Direction.TOP) +
             path.downwardNodes.map { OrientedNodeType(it.getTypeLabel(), Direction.DOWN) }
     return PathContext(startToken, astNodes, endToken)
 }

--- a/src/main/kotlin/astminer/paths/PathUtil.kt
+++ b/src/main/kotlin/astminer/paths/PathUtil.kt
@@ -2,8 +2,6 @@ package astminer.paths
 
 import astminer.common.model.*
 
-typealias PathPiece = List<Node>
-
 fun toPathContext(path: ASTPath, getToken: (Node) -> String = { node -> node.getToken() }): PathContext {
     val startToken = getToken(path.upwardNodes.first())
     val endToken = getToken(path.downwardNodes.last())

--- a/src/main/kotlin/astminer/paths/PathWorker.kt
+++ b/src/main/kotlin/astminer/paths/PathWorker.kt
@@ -3,73 +3,77 @@ package astminer.paths
 import astminer.common.model.ASTPath
 import astminer.common.model.Node
 import astminer.common.postOrderIterator
+import kotlin.math.min
 
 class PathWorker {
 
     companion object {
-        private const val LEAF_INDEX_KEY = "leaf_index"
         private const val PATH_PIECES_KEY = "path_pieces"
 
-        private fun Node.setLeafIndex(index: Int) {
-            this.setMetadata(LEAF_INDEX_KEY, index)
-        }
-
-        private fun Node.getLeafIndex(): Int = this.getMetadata(LEAF_INDEX_KEY) as Int
-
-        private fun Node.setPathPieces(pathPieces: List<List<Node>>) {
+        private fun Node.setPathPieces(pathPieces: List<PathPiece>) {
             this.setMetadata(PATH_PIECES_KEY, pathPieces)
         }
 
-        private fun Node.getPathPieces(): List<List<Node>> = this.getMetadata(PATH_PIECES_KEY) as List<List<Node>>
+        private fun Node.getPathPieces(): List<PathPiece> = this.getMetadata(PATH_PIECES_KEY) as List<PathPiece>
     }
 
     fun retrievePaths(tree: Node) = retrievePaths(tree, Int.MAX_VALUE, Int.MAX_VALUE)
 
-    data class PathPiece(val childIndex: Int, val nodes: List<Node>)
+    fun updatePathPieces(
+            currentNode: Node,
+            pathPiecesPerChild: List<List<PathPiece>>,
+            maxLength: Int
+    ) = pathPiecesPerChild.flatMap { childPieces ->
+        childPieces.mapNotNull { pathPiece ->
+            if (pathPiece.size <= maxLength) {
+                pathPiece + currentNode
+            } else {
+                null
+            }
+        }
+    }
 
-    fun collapsePiecesToPaths(pathPieces: Collection<PathPiece>, maxWidth: Int): Collection<ASTPath> {
+    fun collapsePiecesToPaths(
+            currentNode: Node,
+            pathPiecesPerChild: List<List<PathPiece>>,
+            maxLength: Int, maxWidth: Int
+    ): Collection<ASTPath> {
         val paths: MutableCollection<ASTPath> = ArrayList()
-        val sortedPieces = pathPieces.sortedBy { (it.nodes[0].getLeafIndex()) }
-        sortedPieces.forEachIndexed { index, upPiece ->
-            for (downPiece in sortedPieces.subList(index + 1, sortedPieces.size)) {
-                if (upPiece.childIndex == downPiece.childIndex) continue
-
-                val width = downPiece.nodes[0].getLeafIndex() - upPiece.nodes[0].getLeafIndex()
-                if (width <= maxWidth) {
-                    paths.add(ASTPath(upPiece.nodes, downPiece.nodes.reversed()))
+        val childrenCount = pathPiecesPerChild.size
+        pathPiecesPerChild.forEachIndexed { index, leftChildPieces ->
+            val maxIndex = if (maxWidth == Int.MAX_VALUE || index + maxWidth + 1 >= childrenCount) {
+                childrenCount
+            } else {
+                index + maxWidth + 1
+            }
+            pathPiecesPerChild.subList(index + 1, maxIndex).forEach { rightChildPieces ->
+                leftChildPieces.forEach { upPiece ->
+                    rightChildPieces.forEach { downPiece ->
+                        if (upPiece.size + 1 + downPiece.size <= maxLength) {
+                            paths.add(ASTPath(upPiece, currentNode, downPiece.asReversed()))
+                        }
+                    }
                 }
             }
         }
         return paths
     }
 
-    fun retrievePaths(tree: Node, maxHeight: Int, maxWidth: Int): Collection<ASTPath> {
+    fun retrievePaths(tree: Node, maxLength: Int, maxWidth: Int): Collection<ASTPath> {
         val iterator = tree.postOrderIterator()
-        var currentLeafIndex = 0
         val paths: MutableList<ASTPath> = ArrayList()
         iterator.forEach { currentNode ->
             if (currentNode.isLeaf()) {
-                currentNode.setLeafIndex(currentLeafIndex++)
-                currentNode.setPathPieces(listOf(listOf(currentNode)))
-            } else {
-
-                val pathPiecesPerChild = currentNode.getChildren()
-                        .map { it.getPathPieces() }
-
-                val pathPieces: MutableList<PathPiece> = ArrayList()
-
-                pathPiecesPerChild.forEachIndexed { childIndex, childPieces ->
-                    childPieces.forEach {
-                        if (it.size <= maxHeight) {
-                            pathPieces.add(PathPiece(childIndex, it + currentNode))
-                        }
-                    }
+                if (currentNode.getToken().isNotEmpty()) {
+                    currentNode.setPathPieces(listOf(listOf(currentNode)))
                 }
+            } else {
+                val pathPiecesPerChild = currentNode.getChildren().map { it.getPathPieces() }
+                val currentNodePathPieces = updatePathPieces(currentNode, pathPiecesPerChild, maxLength)
+                val currentNodePaths = collapsePiecesToPaths(currentNode, pathPiecesPerChild, maxLength, maxWidth)
 
-                val currentNodePaths = collapsePiecesToPaths(pathPieces, maxWidth)
                 paths.addAll(currentNodePaths)
-
-                currentNode.setPathPieces(pathPieces.map { it.nodes })
+                currentNode.setPathPieces(currentNodePathPieces)
             }
         }
         return paths

--- a/src/main/kotlin/astminer/paths/PathWorker.kt
+++ b/src/main/kotlin/astminer/paths/PathWorker.kt
@@ -2,6 +2,7 @@ package astminer.paths
 
 import astminer.common.model.ASTPath
 import astminer.common.model.Node
+import astminer.common.model.PathPiece
 import astminer.common.postOrderIterator
 
 class PathWorker {

--- a/src/main/kotlin/astminer/paths/PathWorker.kt
+++ b/src/main/kotlin/astminer/paths/PathWorker.kt
@@ -3,7 +3,6 @@ package astminer.paths
 import astminer.common.model.ASTPath
 import astminer.common.model.Node
 import astminer.common.postOrderIterator
-import kotlin.math.min
 
 class PathWorker {
 
@@ -14,28 +13,28 @@ class PathWorker {
             this.setMetadata(PATH_PIECES_KEY, pathPieces)
         }
 
-        private fun Node.getPathPieces(): List<PathPiece> = this.getMetadata(PATH_PIECES_KEY) as List<PathPiece>
+        private fun Node.getPathPieces(): List<PathPiece>? = this.getMetadata(PATH_PIECES_KEY) as List<PathPiece>?
     }
 
     fun retrievePaths(tree: Node) = retrievePaths(tree, Int.MAX_VALUE, Int.MAX_VALUE)
 
     fun updatePathPieces(
             currentNode: Node,
-            pathPiecesPerChild: List<List<PathPiece>>,
+            pathPiecesPerChild: List<List<PathPiece>?>,
             maxLength: Int
     ) = pathPiecesPerChild.flatMap { childPieces ->
-        childPieces.mapNotNull { pathPiece ->
+        childPieces?.mapNotNull { pathPiece ->
             if (pathPiece.size <= maxLength) {
                 pathPiece + currentNode
             } else {
                 null
             }
-        }
+        } ?: emptyList()
     }
 
     fun collapsePiecesToPaths(
             currentNode: Node,
-            pathPiecesPerChild: List<List<PathPiece>>,
+            pathPiecesPerChild: List<List<PathPiece>?>,
             maxLength: Int, maxWidth: Int
     ): Collection<ASTPath> {
         val paths: MutableCollection<ASTPath> = ArrayList()
@@ -47,8 +46,8 @@ class PathWorker {
                 index + maxWidth + 1
             }
             pathPiecesPerChild.subList(index + 1, maxIndex).forEach { rightChildPieces ->
-                leftChildPieces.forEach { upPiece ->
-                    rightChildPieces.forEach { downPiece ->
+                leftChildPieces?.forEach { upPiece ->
+                    rightChildPieces?.forEach { downPiece ->
                         if (upPiece.size + 1 + downPiece.size <= maxLength) {
                             paths.add(ASTPath(upPiece, currentNode, downPiece.asReversed()))
                         }

--- a/src/main/kotlin/astminer/paths/PathWorker.kt
+++ b/src/main/kotlin/astminer/paths/PathWorker.kt
@@ -23,14 +23,12 @@ class PathWorker {
             currentNode: Node,
             pathPiecesPerChild: List<List<PathPiece>?>,
             maxLength: Int
-    ) = pathPiecesPerChild.flatMap { childPieces ->
-        childPieces?.mapNotNull { pathPiece ->
-            if (pathPiece.size <= maxLength) {
-                pathPiece + currentNode
-            } else {
-                null
-            }
-        } ?: emptyList()
+    ) = pathPiecesPerChild.filterNotNull().flatMap { childPieces ->
+        childPieces.filter { pathPiece ->
+            pathPiece.size <= maxLength
+        }.map { pathPiece ->
+            pathPiece + currentNode
+        }
     }
 
     fun collapsePiecesToPaths(

--- a/src/test/kotlin/astminer/cli/util/CliArgs.kt
+++ b/src/test/kotlin/astminer/cli/util/CliArgs.kt
@@ -14,8 +14,8 @@ class CliArgs private constructor(val args: List<String>) {
             args.add(extensions)
         }
 
-        fun maxPathHeight(h: Int) = apply {
-            args.add("--maxH")
+        fun maxPathLength(h: Int) = apply {
+            args.add("--maxL")
             args.add(h.toString())
         }
 

--- a/src/test/kotlin/astminer/cli/util/CliArgs.kt
+++ b/src/test/kotlin/astminer/cli/util/CliArgs.kt
@@ -14,9 +14,9 @@ class CliArgs private constructor(val args: List<String>) {
             args.add(extensions)
         }
 
-        fun maxPathLength(h: Int) = apply {
+        fun maxPathLength(l: Int) = apply {
             args.add("--maxL")
-            args.add(h.toString())
+            args.add(l.toString())
         }
 
         fun maxPathWidth(w: Int) = apply {

--- a/src/test/kotlin/astminer/paths/PathWorkerTestBase.kt
+++ b/src/test/kotlin/astminer/paths/PathWorkerTestBase.kt
@@ -28,33 +28,6 @@ abstract class PathWorkerTestBase {
     }
 
     @Test
-    fun pathsCountWidth1() {
-        val tree = getTree()
-        val nLeaves = tree.postOrder().count { it.isLeaf() }
-
-        val allPaths = PathWorker().retrievePaths(tree, Int.MAX_VALUE, 1)
-        val expectedCount = nLeaves - 1
-
-        Assert.assertEquals("A tree with $nLeaves leaves contains $expectedCount paths of width 1. " +
-                "Worker returned ${allPaths.size}",
-                expectedCount, allPaths.size)
-    }
-
-    @Test
-    fun pathsCountAnyWidth() {
-        val tree = getTree()
-        val nLeaves = tree.postOrder().count { it.isLeaf() }
-
-        for (maxWidth in 1..nLeaves) {
-            val paths = PathWorker().retrievePaths(tree, Int.MAX_VALUE, maxWidth)
-            val expectedPathsCount = getPathsCountWithNoHeightLimit(nLeaves, maxWidth)
-            Assert.assertEquals("A tree with $nLeaves nodes should contain $expectedPathsCount paths " +
-                    "of width up to $maxWidth, worker returned ${paths.size}",
-                    expectedPathsCount, paths.size)
-        }
-    }
-
-    @Test
     fun pathValidity() {
         val tree = getTree()
 
@@ -65,44 +38,35 @@ abstract class PathWorkerTestBase {
     }
 
     @Test
-    fun countFunctionsMatch() {
-        val tree = getTree()
-        val leavesCount = tree.postOrder().count { it.isLeaf() }
-
-        for (maxWidth in 1..leavesCount) {
-            Assert.assertEquals(getPathsCountWithNoHeightLimit(leavesCount, maxWidth),
-                    countPossiblePaths(tree, Int.MAX_VALUE, maxWidth))
-        }
-    }
-
-    @Test
     fun countsForAllLimitCombinations() {
-        val maxHeightLimit = 100
+        val maxLengthLimit = 100
 
         val tree = getTree()
         val leavesCount = tree.postOrder().count { it.isLeaf() }
+        val allPathCharacteristics = getAllPathCharacteristics(tree)
 
-        for (maxHeight in 1..maxHeightLimit) {
+        for (maxLength in 1..maxLengthLimit) {
             for (maxWidth in 1..leavesCount) {
-                val paths = PathWorker().retrievePaths(tree, maxHeight, maxWidth)
+                val paths = PathWorker().retrievePaths(tree, maxLength, maxWidth)
                 Assert.assertEquals(
-                        "Unexpected paths count with height $maxHeight and width $maxWidth",
-                        countPossiblePaths(tree, maxHeight, maxWidth),
-                        paths.size)
+                        "Unexpected paths count with length $maxLength and width $maxWidth",
+                        allPathCharacteristics.count { (w, len) -> w <= maxWidth && len <= maxLength },
+                        paths.size
+                )
             }
         }
     }
 
     @Test
     fun validityForAllLimitCombinations() {
-        val maxHeightLimit = 100
+        val maxLengthLimit = 100
 
         val tree = getTree()
         val leavesCount = tree.postOrder().count { it.isLeaf() }
 
-        for (maxHeight in 1..maxHeightLimit) {
+        for (maxLength in 1..maxLengthLimit) {
             for (maxWidth in 1..leavesCount) {
-                val paths = PathWorker().retrievePaths(tree, maxHeight, maxWidth)
+                val paths = PathWorker().retrievePaths(tree, maxLength, maxWidth)
                 paths.forEach { assertPathIsValid(it) }
             }
         }


### PR DESCRIPTION
* Change height parameter to length in order to avoid confusion in code2vec/code2seq.
* Follow the original code2seq implementation to compute width. Previously it was the difference between leaf indices, now we compute it as the difference between indices of nodes next to the path top.