### PR TITLE
Update version of C/C++ parser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,9 +52,9 @@ dependencies {
     api("com.github.gumtreediff", "gen.jdt", "2.1.0")
 
     // https://mvnrepository.com/artifact/io.shiftleft/fuzzyc2cpg
-    api("io.shiftleft", "fuzzyc2cpg_2.12", "0.1.74") {
-        exclude("org.slf4j", "slf4j-simple")
-    }
+    api("io.shiftleft", "fuzzyc2cpg_2.13", "1.2.9")
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+    testImplementation("org.slf4j", "slf4j-simple", "1.7.30")
 
     testImplementation("junit:junit:4.11")
     testImplementation(kotlin("test-junit"))

--- a/src/main/kotlin/astminer/common/model/ParsingModel.kt
+++ b/src/main/kotlin/astminer/common/model/ParsingModel.kt
@@ -49,14 +49,6 @@ interface Parser<T : Node> {
     /**
      * Parse list of files.
      * @param files files to parse
-     * @return list of ParseResult instances, one for each parsed file
-     */
-    @Deprecated("Please use parseFiles (List<File>, (ParseResult<T>) -> Any) to avoid clogging memory")
-    fun parseFiles(files: List<File>): List<ParseResult<T>> = files.map { ParseResult(parseInputStream(it.inputStream()), it.path) }
-
-    /**
-     * Parse list of files.
-     * @param files files to parse
      * @param handleResult handler to invoke on each file parse result
      */
     fun parseFiles(files: List<File>, handleResult: (ParseResult<T>) -> Any) {

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -157,18 +157,6 @@ class FuzzyCppParser : Parser<FuzzyNode> {
         }
     }
 
-    /**
-     * Create string from element with its label and all its properties.
-     * @param e - element for converting to string
-     * @return created string
-     */
-    fun elementToString(e: Element) = with(StringBuilder()) {
-        append("${e.label()}  |  ")
-        e.propertyKeys().forEach { k -> append("$k:${e.property(k)}  ") }
-        appendln()
-        toString()
-    }
-
     private fun addNodesFromEdge(e: Edge, map: MutableMap<Node, FuzzyNode>) {
         val parentNode = map.getOrPut(e.outNode()) { createNodeFromVertex(e.outNode()) }
         val childNode = map.getOrPut(e.inNode()) { createNodeFromVertex(e.inNode()) }

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -124,7 +124,7 @@ class FuzzyCppParser : Parser<FuzzyNode> {
         g.V().forEach {
             if (it.label() == NodeTypes.FILE) {
                 val actualFilePath = it.property("NAME").toString()
-                if (actualFilePath != filePath) {
+                if (File(actualFilePath).absolutePath != File(filePath).absolutePath) {
                     println("While parsing $filePath, actually parsed $actualFilePath")
                 }
                 return ParseResult(vertexToNode[it], actualFilePath)

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -110,7 +110,7 @@ class FuzzyCppParser : Parser<FuzzyNode> {
      */
     private fun cpg2Nodes(cpg: Cpg, filePath: String): ParseResult<FuzzyNode> {
         val g = cpg.graph()
-        val vertexToNode = HashMap<Node, FuzzyNode>()
+        val vertexToNode = mutableMapOf<Node, FuzzyNode>()
         g.E().forEach {
             if (it.label() == EdgeTypes.AST) {
                 addNodesFromEdge(it, vertexToNode)
@@ -169,7 +169,7 @@ class FuzzyCppParser : Parser<FuzzyNode> {
         toString()
     }
 
-    private fun addNodesFromEdge(e: Edge, map: HashMap<Node, FuzzyNode>) {
+    private fun addNodesFromEdge(e: Edge, map: MutableMap<Node, FuzzyNode>) {
         val parentNode = map.getOrPut(e.outNode()) { createNodeFromVertex(e.outNode()) }
         val childNode = map.getOrPut(e.inNode()) { createNodeFromVertex(e.inNode()) }
         parentNode.addChild(childNode)

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -101,11 +101,6 @@ class FuzzyCppParser : Parser<FuzzyNode> {
     }
 
     /**
-     * @see [Parser.parseInputStream]
-     */
-    override fun parseFiles(files: List<File>): List<ParseResult<FuzzyNode>> = files.map { parseFile(it) }
-
-    /**
      * Convert [cpg][io.shiftleft.codepropertygraph.Cpg] created by fuzzyc2cpg
      * to list of [FuzzyNode][astminer.parse.cpp.FuzzyNode].
      * Cpg may contain graphs for several files, in that case several ASTs will be created.

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -52,13 +52,13 @@ class FuzzyCppParser : Parser<FuzzyNode> {
         data class ReplaceableNodeKey(val key: String, val condition: (Node) -> Boolean)
 
         private val replaceableNodeKeys = listOf(
-            ReplaceableNodeKey("NAME") { v ->
-                v.propertyKeys().contains("NAME") &&
-                        v.property("NAME").toString().startsWith("<operator>")
-            },
-            ReplaceableNodeKey("PARSER_TYPE_NAME") { v ->
-                v.propertyKeys().contains("PARSER_TYPE_NAME")
-            }
+                ReplaceableNodeKey("NAME") { v ->
+                    v.propertyKeys().contains("NAME") &&
+                            v.property("NAME").toString().startsWith("<operator>")
+                },
+                ReplaceableNodeKey("PARSER_TYPE_NAME") { v ->
+                    v.propertyKeys().contains("PARSER_TYPE_NAME")
+                }
         )
     }
 

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -101,6 +101,11 @@ class FuzzyCppParser : Parser<FuzzyNode> {
     }
 
     /**
+     * @see [Parser.parseInputStream]
+     */
+    override fun parseFiles(files: List<File>): List<ParseResult<FuzzyNode>> = files.map { parseFile(it) }
+
+    /**
      * Convert [cpg][io.shiftleft.codepropertygraph.Cpg] created by fuzzyc2cpg
      * to list of [FuzzyNode][astminer.parse.cpp.FuzzyNode].
      * Cpg may contain graphs for several files, in that case several ASTs will be created.

--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -2,17 +2,16 @@ package astminer.parse.cpp
 
 import astminer.common.model.ParseResult
 import astminer.common.model.Parser
-import gremlin.scala.Key
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
-import io.shiftleft.fuzzyc2cpg.output.inmemory.OutputModuleFactory
-import org.apache.commons.io.FileUtils
-import org.apache.tinkerpop.gremlin.structure.Edge
-import org.apache.tinkerpop.gremlin.structure.Element
-import org.apache.tinkerpop.gremlin.structure.Vertex
+import overflowdb.Edge
+import overflowdb.Node
+import overflowdb.Element
+import scala.Option
+import scala.collection.immutable.Set
 import java.io.File
 import java.io.InputStream
 
@@ -50,22 +49,22 @@ class FuzzyCppParser : Parser<FuzzyNode> {
                 ), 0)
         )
 
-        data class ReplaceableNodeKey(val key: String, val condition: (Vertex) -> Boolean)
+        data class ReplaceableNodeKey(val key: String, val condition: (Node) -> Boolean)
 
         private val replaceableNodeKeys = listOf(
-                ReplaceableNodeKey("NAME") { v ->
-                    v.keys().contains("NAME") &&
-                            v.value<String>("NAME").startsWith("<operator>")
-                },
-                ReplaceableNodeKey("PARSER_TYPE_NAME") { v ->
-                    v.keys().contains("PARSER_TYPE_NAME")
-                }
+            ReplaceableNodeKey("NAME") { v ->
+                v.propertyKeys().contains("NAME") &&
+                        v.property("NAME").toString().startsWith("<operator>")
+            },
+            ReplaceableNodeKey("PARSER_TYPE_NAME") { v ->
+                v.propertyKeys().contains("PARSER_TYPE_NAME")
+            }
         )
     }
 
     /**
      * Parse input stream and create an AST.
-     * If you already have a file with code you need to parse, better use [parseFiles] or [parseInputStream],
+     * If you already have a file with code you need to parse, better use [parseFile],
      * otherwise temporary file for input stream will be created because of fuzzyc2cpg API.
      * @param content to parse
      * @return root of AST if content was parsed, null otherwise
@@ -73,20 +72,32 @@ class FuzzyCppParser : Parser<FuzzyNode> {
     override fun parseInputStream(content: InputStream): FuzzyNode? {
         val file = File.createTempFile("fuzzy", ".cpp")
         file.deleteOnExit()
-        FileUtils.copyInputStreamToFile(content, file)
-        val nodes = parseFiles(listOf(file))
-        return nodes[0].root
+        file.outputStream().use {
+            content.copyTo(it)
+        }
+        val nodes = parseFile(file)
+        return nodes.root
     }
 
     /**
-     * @see [Parser.parseInputStream]
+     * Parse a single file and create an AST.
+     * @param file to parse
+     * @return [ParseResult] with root of an AST (null if parsing failed) and file path
      */
-    override fun parseFiles(files: List<File>): List<ParseResult<FuzzyNode>> {
-        val outputModuleFactory = OutputModuleFactory()
-        val paths = files.map { it.path }
-        FuzzyC2Cpg(outputModuleFactory).runAndOutput(paths.toTypedArray())
-        val cpg = outputModuleFactory.internalGraph
-        return cpg2Nodes(cpg)
+    override fun parseFile(file: File): ParseResult<FuzzyNode> {
+        // We need some tweaks to create Scala sets from Kotlin code
+        val pathSetScalaBuilder = Set.newBuilder<String>()
+        pathSetScalaBuilder.addOne(file.path)
+        val pathSet = pathSetScalaBuilder.result()
+        val extensionSetScalaBuilder = Set.newBuilder<String>()
+        extensionSetScalaBuilder.addOne(".${file.extension}")
+        val extensionSet = extensionSetScalaBuilder.result()
+
+        // Kotlin cannot use default value Scala:None for the argument, so we create it manually
+        val optionalOutputPath: Option<String> = Option.empty()
+
+        val cpg = FuzzyC2Cpg().runAndOutput(pathSet, extensionSet, optionalOutputPath)
+        return cpg2Nodes(cpg, file.path)
     }
 
     /**
@@ -94,13 +105,27 @@ class FuzzyCppParser : Parser<FuzzyNode> {
      * to list of [FuzzyNode][astminer.parse.cpp.FuzzyNode].
      * Cpg may contain graphs for several files, in that case several ASTs will be created.
      * @param cpg to be converted
+     * @param filePath to the parsed file that will be used if parsing failed
      * @return list of AST roots
      */
-    private fun cpg2Nodes(cpg: Cpg): List<ParseResult<FuzzyNode>> {
-        val g = cpg.graph().traversal()
-        val vertexToNode = HashMap<Vertex, FuzzyNode>()
-        g.E().hasLabel(EdgeTypes.AST).forEach { addNodesFromEdge(it, vertexToNode) }
-        return g.V().hasLabel(NodeTypes.FILE).toList().map { ParseResult(vertexToNode[it], it.value("NAME")) }
+    private fun cpg2Nodes(cpg: Cpg, filePath: String): ParseResult<FuzzyNode> {
+        val g = cpg.graph()
+        val vertexToNode = HashMap<Node, FuzzyNode>()
+        g.E().forEach {
+            if (it.label() == EdgeTypes.AST) {
+                addNodesFromEdge(it, vertexToNode)
+            }
+        }
+        g.V().forEach {
+            if (it.label() == NodeTypes.FILE) {
+                val actualFilePath = it.property("NAME").toString()
+                if (actualFilePath != filePath) {
+                    println("While parsing $filePath, actually parsed $actualFilePath")
+                }
+                return ParseResult(vertexToNode[it], actualFilePath)
+            }
+        }
+        return ParseResult(null, filePath)
     }
 
     /**
@@ -139,50 +164,44 @@ class FuzzyCppParser : Parser<FuzzyNode> {
      */
     fun elementToString(e: Element) = with(StringBuilder()) {
         append("${e.label()}  |  ")
-        e.keys().forEach { k -> append("$k:${e.value<Any>(k)}  ") }
+        e.propertyKeys().forEach { k -> append("$k:${e.property(k)}  ") }
         appendln()
         toString()
     }
 
-    private fun addNodesFromEdge(e: Edge, map: HashMap<Vertex, FuzzyNode>) {
-        val parentNode = map.getOrPut(e.outVertex()) { createNodeFromVertex(e.outVertex()) }
-        val childNode = map.getOrPut(e.inVertex()) { createNodeFromVertex(e.inVertex()) }
+    private fun addNodesFromEdge(e: Edge, map: HashMap<Node, FuzzyNode>) {
+        val parentNode = map.getOrPut(e.outNode()) { createNodeFromVertex(e.outNode()) }
+        val childNode = map.getOrPut(e.inNode()) { createNodeFromVertex(e.inNode()) }
         parentNode.addChild(childNode)
     }
 
-    private fun createNodeFromVertex(v: Vertex): FuzzyNode {
-        val token: String? = v.getValueOrNull(NodeKeys.CODE)
-        val order: Int? = v.getValueOrNull(NodeKeys.ORDER)
+    private fun createNodeFromVertex(v: Node): FuzzyNode {
+        val token: String? = v.property(NodeKeys.CODE)
+        val order: Int? = v.property(NodeKeys.ORDER)
 
         for (replaceableNodeKey in replaceableNodeKeys) {
             if (replaceableNodeKey.condition(v)) {
-                val node = FuzzyNode(v.value<String>(replaceableNodeKey.key), token, order)
-                v.keys().forEach { k ->
-                    node.setMetadata(k, v.value(k))
+                val node = FuzzyNode(v.property(replaceableNodeKey.key).toString(), token, order)
+                v.propertyKeys().forEach { k ->
+                    val property = v.property(k) ?: return@forEach
+                    node.setMetadata(k, property.toString())
                 }
                 return node
             }
         }
 
         val node = FuzzyNode(v.label(), token, order)
-        v.keys().forEach { k ->
+        v.propertyKeys().forEach { k ->
+            val property = v.property(k)?.toString() ?: return@forEach
             for (expandableNodeKey in expandableNodeKeys) {
                 if (expandableNodeKey.key == k && expandableNodeKey.supportedNodeLabels.contains(v.label())) {
-                    val keyNode = FuzzyNode(k, v.value<Any>(k).toString(), expandableNodeKey.order)
+                    val keyNode = FuzzyNode(k, property, expandableNodeKey.order)
                     node.addChild(keyNode)
                     return@forEach
                 }
             }
-            node.setMetadata(k, v.value(k))
+            node.setMetadata(k, property)
         }
         return node
-    }
-
-    private fun <T> Vertex.getValueOrNull(key: Key<out Any>): T? {
-        return try {
-            this.value<T>(key.name())
-        } catch (e: IllegalStateException) {
-            null
-        }
     }
 }

--- a/src/test/kotlin/astminer/parse/antlr/java/ANTLRJavaParserTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/java/ANTLRJavaParserTest.kt
@@ -1,6 +1,7 @@
 package astminer.parse.antlr.java
 
 import astminer.common.getProjectFilesWithExtension
+import astminer.common.model.Node
 import org.junit.Assert
 import org.junit.Test
 import java.io.File
@@ -57,8 +58,8 @@ class ANTLRJavaParserTest {
     fun testProjectParsing() {
         val parser = JavaParser()
         val projectRoot = File("src/test/resources/arrayCalls")
-        val trees = parser.parseFiles(
-            getProjectFilesWithExtension(projectRoot, "java")).map { it.root }
+        val trees = mutableListOf<Node?>()
+        parser.parseFiles(getProjectFilesWithExtension(projectRoot, "java")) { trees.add(it.root) }
         Assert.assertEquals("There is only 5 file with .java extension in 'testData/arrayCalls' folder",5, trees.size)
         trees.forEach { Assert.assertNotNull("Parse tree for a valid file should not be null", it) }
     }

--- a/src/test/kotlin/astminer/parse/antlr/python/ANTLRPythonParserTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/python/ANTLRPythonParserTest.kt
@@ -1,6 +1,7 @@
 package astminer.parse.antlr.python
 
 import astminer.common.getProjectFilesWithExtension
+import astminer.common.model.Node
 import org.junit.Assert
 import org.junit.Test
 import java.io.File
@@ -20,7 +21,8 @@ class ANTLRPythonParserTest {
     fun testProjectParsing() {
         val parser = PythonParser()
         val projectRoot = File("src/test/resources/examples")
-        val trees = parser.parseFiles(getProjectFilesWithExtension(projectRoot, "py")).map { it.root }
+        val trees = mutableListOf<Node?>()
+        parser.parseFiles(getProjectFilesWithExtension(projectRoot, "py")) { trees.add(it.root) }
         Assert.assertEquals("There is only 1 file with .py extension in 'testData/examples' folder",1, trees.size)
         trees.forEach { Assert.assertNotNull("Parse tree for a valid file should not be null", it) }
     }

--- a/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
+++ b/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
@@ -14,6 +14,7 @@ class FuzzyCppParserTest {
         val file = File("src/test/resources/fuzzy/test.cpp")
 
         val nodes = parser.parseFiles(listOf(file))
+        nodes[0].root?.prettyPrint()
         Assert.assertTrue("Parse tree for a valid file should not be null",
                 nodes.size == 1 && nodes[0].root != null)
     }
@@ -35,7 +36,10 @@ class FuzzyCppParserTest {
     fun testProjectParsing() {
         val folder = File("src/test/resources/fuzzy/")
         val parser = FuzzyCppParser()
-        val nodes = parser.parseFiles(getProjectFilesWithExtension(folder,"cpp")).map { it.root }
+        val nodes = mutableListOf<FuzzyNode?>()
+        parser.parseFiles(getProjectFilesWithExtension(folder,"cpp")) {
+            nodes.add(it.root)
+        }
         Assert.assertEquals(
                 "There is only 3 file with .cpp extension in 'testData/examples' folder",
                 3,

--- a/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
+++ b/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
@@ -14,7 +14,7 @@ class FuzzyCppParserTest {
         val file = File("src/test/resources/fuzzy/test.cpp")
 
         val nodes = parser.parseFile(file)
-        Assert.assertTrue("Parse tree for a valid file should not be null",nodes.root != null)
+        Assert.assertTrue("Parse tree for a valid file should not be null", nodes.root != null)
     }
 
     @Test
@@ -35,7 +35,7 @@ class FuzzyCppParserTest {
         val folder = File("src/test/resources/fuzzy/")
         val parser = FuzzyCppParser()
         val nodes = mutableListOf<FuzzyNode?>()
-        parser.parseFiles(getProjectFilesWithExtension(folder,"cpp")) {
+        parser.parseFiles(getProjectFilesWithExtension(folder, "cpp")) {
             nodes.add(it.root)
         }
         Assert.assertEquals(

--- a/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
+++ b/src/test/kotlin/astminer/parse/cpp/FuzzyCppParserTest.kt
@@ -13,10 +13,8 @@ class FuzzyCppParserTest {
         val parser = FuzzyCppParser()
         val file = File("src/test/resources/fuzzy/test.cpp")
 
-        val nodes = parser.parseFiles(listOf(file))
-        nodes[0].root?.prettyPrint()
-        Assert.assertTrue("Parse tree for a valid file should not be null",
-                nodes.size == 1 && nodes[0].root != null)
+        val nodes = parser.parseFile(file)
+        Assert.assertTrue("Parse tree for a valid file should not be null",nodes.root != null)
     }
 
     @Test
@@ -91,7 +89,10 @@ class FuzzyCppParserTest {
         val parser = FuzzyCppParser()
 
         parser.preprocessProject(projectRoot, preprocessedRoot)
-        val nodes = parser.parseFiles(getProjectFilesWithExtension(projectRoot, "cpp")).map { it.root }
+        val nodes = mutableListOf<FuzzyNode?>()
+        parser.parseFiles(getProjectFilesWithExtension(projectRoot, "cpp")) {
+            nodes.add(it.root)
+        }
 
         Assert.assertEquals(
                 "Parse tree for a valid file should not be null. There are 5 files in example project.",

--- a/src/test/kotlin/astminer/parse/java/GumTreeJavaParserTest.kt
+++ b/src/test/kotlin/astminer/parse/java/GumTreeJavaParserTest.kt
@@ -1,6 +1,7 @@
 package astminer.parse.java
 
 import astminer.common.getProjectFilesWithExtension
+import astminer.common.model.Node
 import org.junit.Assert
 import org.junit.Test
 import java.io.*
@@ -19,7 +20,9 @@ class GumTreeJavaParserTest {
     fun testProjectParsing() {
         val parser = GumTreeJavaParser()
         val projectRoot = File("src/test/resources/examples")
-        val trees = parser.parseFiles(getProjectFilesWithExtension(projectRoot, "java")).map { it.root }
+        
+        val trees = mutableListOf<Node?>() 
+        parser.parseFiles(getProjectFilesWithExtension(projectRoot, "java")) { trees.add(it.root) }
         Assert.assertEquals("There is only 2 file with .java extension in 'testData/examples' folder",2, trees.size)
         trees.forEach { Assert.assertNotNull("Parse tree for a valid file should not be null", it) }
     }


### PR DESCRIPTION
We use an outdated version of FuzzyC2CPG parser, so it's time to switch to a new one (the project migrated [here](https://github.com/ShiftLeftSecurity/codepropertygraph)).
1. Updated version of FuzzyC2CPG
2. Integrated the new API into our FuzzyCppParser
3. Switched from `parseFiles` as a default parsing method to `parseFile`, since the usage of `parseFiles` is deprecated