### PR TITLE
cli.sh to work with any release

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -jar build/shadow/lib-0.5.jar "$@"
+java -jar build/shadow/lib-*.jar "$@"


### PR DESCRIPTION
Otherwise, it fails on the current master, where there is no `lib-0.5.jar` after `./gradlew buildShadow`.