### PR TITLE
Do not fail preprocessing for the files on top of the directory

### DIFF
--- a/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
+++ b/src/main/kotlin/astminer/parse/cpp/FuzzyCppParser.kt
@@ -151,7 +151,11 @@ class FuzzyCppParser : Parser<FuzzyNode> {
                 .filter { file -> supportedExtensions.contains(file.extension) }
         files.forEach { file ->
             val relativeFilePath = file.relativeTo(projectRoot)
-            val outputPath = outputDir.resolve(relativeFilePath.parent)
+            val outputPath = if (relativeFilePath.parent != null){
+                outputDir.resolve(relativeFilePath.parent)
+            } else {
+                outputDir
+            }
             outputPath.mkdirs()
             preprocessFile(file, outputPath)
         }


### PR DESCRIPTION
Previously preprocessing failed when the file lies right in the input directory root (see #118). The introduced `if` fixes the problem.