### PR TITLE
Fix group name of maven artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.github.vovak.astminer:astminer:0.6.0'
+    compile 'io.github.vovak:astminer:0.6.0'
 }
 ```
 
@@ -111,7 +111,7 @@ repositories {
 }
 
 dependencies {
-    compile("io.github.vovak.astminer", "astminer", "0.6.0")
+    compile("io.github.vovak", "astminer", "0.6.0")
 }
 ```
 


### PR DESCRIPTION
Tried using the new dependency coordinates as per #124, but Gradle was unable to resolve it. After replacing the group name `io.github.vovak` with `io.github.vovak.astminer`, it worked as expected.