### PR TITLE
Fix for alternative array parameter

### DIFF
--- a/src/main/kotlin/astminer/parse/antlr/java/AntlrJavaFunctionInfo.kt
+++ b/src/main/kotlin/astminer/parse/antlr/java/AntlrJavaFunctionInfo.kt
@@ -59,7 +59,7 @@ class AntlrJavaFunctionInfo(override val root: AntlrNode) : FunctionInfo<AntlrNo
         val returnTypeNode = parameterNode.getChildOfType(PARAMETER_RETURN_TYPE_NODE)
         val returnTypeToken = returnTypeNode?.getTokensFromSubtree()
 
-        val parameterName = parameterNode.getChildOfType(PARAMETER_NAME_NODE)?.originalToken
+        val parameterName = parameterNode.getChildOfType(PARAMETER_NAME_NODE)?.getTokensFromSubtree()
             ?: throw IllegalStateException("Parameter name wasn't found")
 
         return FunctionInfoParameter(parameterName, returnTypeToken)

--- a/src/test/kotlin/astminer/parse/antlr/java/JavaFunctionSplitterTest.kt
+++ b/src/test/kotlin/astminer/parse/antlr/java/JavaFunctionSplitterTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNotNull
 
 class JavaFunctionSplitterTest {
     companion object {
-        const val N_FUNCTIONS = 9
+        const val N_FUNCTIONS = 10
         val functionSplitter = JavaFunctionSplitter()
         val parser = JavaParser()
     }
@@ -99,5 +99,15 @@ class JavaFunctionSplitterTest {
             assertEquals("p${i + 1}", parameter.name)
             assertEquals(methodTypes[i], parameter.type)
         }
+    }
+
+    @Test
+    fun testWeirdArrayParameter() {
+        val methodWeirdArrayParameter = functionInfos.find { it.name == "functionWithStrangeArrayParameter" }
+        assertNotNull(methodWeirdArrayParameter)
+        assertEquals(1, methodWeirdArrayParameter.parameters.size)
+        val weirdParameter = methodWeirdArrayParameter.parameters[0]
+        assertEquals(weirdParameter.name, "arr[]")
+        assertEquals(weirdParameter.type, "int")
     }
 }

--- a/src/test/resources/methodSplitting/testMethodSplitting.java
+++ b/src/test/resources/methodSplitting/testMethodSplitting.java
@@ -24,4 +24,6 @@ class Class1 {
     void functionWithOneParameter(int p1) {}
 
     void functionWithThreeParameters(Class p1, String[][] p2, int[]... p3) {}
+
+    void functionWithStrangeArrayParameter(int arr[]) {}
 }


### PR DESCRIPTION
When parsing `public void f(int arr[])`ANTLR Java function info can't find parameter name and crashes. This is a possible fix.