### PR TITLE
Relative paths in parsing result

### DIFF
--- a/src/main/kotlin/astminer/common/model/ParsingResultModel.kt
+++ b/src/main/kotlin/astminer/common/model/ParsingResultModel.kt
@@ -13,8 +13,8 @@ interface ParsingResultFactory {
 
     fun <T> parseFiles(
         files: List<File>,
-        action: (ParsingResult<out Node>) -> T,
-        inputDirectoryPath: String?
+        inputDirectoryPath: String? = null,
+        action: (ParsingResult<out Node>) -> T
     ): List<T?> {
         val results = mutableListOf<T?>()
         files.map { file ->
@@ -42,7 +42,7 @@ interface ParsingResultFactory {
         synchronized(results) {
             files.chunked(ceil(files.size.toDouble() / numOfThreads).toInt()).filter { it.isNotEmpty() }
                 .map { chunk ->
-                    threads.add(thread { results.addAll(parseFiles(chunk, action, inputDirectoryPath)) })
+                    threads.add(thread { results.addAll(parseFiles(chunk, inputDirectoryPath, action)) })
                 }
         }
         threads.map { it.join() }
@@ -60,8 +60,8 @@ interface PreprocessingParsingResultFactory : ParsingResultFactory {
      */
     override fun <T> parseFiles(
         files: List<File>,
-        action: (ParsingResult<out Node>) -> T,
-        inputDirectoryPath: String?
+        inputDirectoryPath: String?,
+        action: (ParsingResult<out Node>) -> T
     ) =
         files.map { file ->
             try {

--- a/src/main/kotlin/astminer/parse/antlr/AntlrParsingResult.kt
+++ b/src/main/kotlin/astminer/parse/antlr/AntlrParsingResult.kt
@@ -12,36 +12,44 @@ import astminer.parse.antlr.python.PythonParser
 import java.io.File
 
 object AntlrJavaParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File) = AntlrJavaParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        AntlrJavaParsingResult(file, inputDirectoryPath)
 
-    class AntlrJavaParsingResult(file: File) : ParsingResult<AntlrNode>(file) {
+    class AntlrJavaParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<AntlrNode>(file, inputDirectoryPath) {
         override val root = JavaParser().parseFile(file)
         override val splitter = JavaFunctionSplitter()
     }
 }
 
 object AntlrPythonParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File) = AntlrPythonParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        AntlrPythonParsingResult(file, inputDirectoryPath)
 
-    class AntlrPythonParsingResult(file: File) : ParsingResult<AntlrNode>(file) {
+    class AntlrPythonParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<AntlrNode>(file, inputDirectoryPath) {
         override val root = PythonParser().parseFile(file)
         override val splitter = PythonFunctionSplitter()
     }
 }
 
 object AntlrJavascriptParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File) = AntlrJavascriptParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        AntlrJavascriptParsingResult(file, inputDirectoryPath)
 
-    class AntlrJavascriptParsingResult(file: File) : ParsingResult<AntlrNode>(file) {
+    class AntlrJavascriptParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<AntlrNode>(file, inputDirectoryPath) {
         override val root = JavaScriptParser().parseFile(file)
         override val splitter = JavaScriptFunctionSplitter()
     }
 }
 
 object AntlrPHPParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File): ParsingResult<out Node> = AntlrPHPParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        AntlrPHPParsingResult(file, inputDirectoryPath)
 
-    class AntlrPHPParsingResult(file: File) : ParsingResult<AntlrNode>(file) {
+    class AntlrPHPParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<AntlrNode>(file, inputDirectoryPath) {
         override val root = PHPParser().parseFile(file)
         override val splitter = PHPFunctionSplitter()
     }

--- a/src/main/kotlin/astminer/parse/fuzzy/FuzzyParsingResultFactory.kt
+++ b/src/main/kotlin/astminer/parse/fuzzy/FuzzyParsingResultFactory.kt
@@ -7,12 +7,12 @@ import astminer.parse.fuzzy.cpp.FuzzyFunctionSplitter
 import java.io.File
 
 object FuzzyParsingResultFactory : PreprocessingParsingResultFactory {
-    override fun parse(file: File): ParsingResult<FuzzyNode> {
+    override fun parse(file: File, inputDirectoryPath: String?): ParsingResult<FuzzyNode> {
         val actualFile = if (file.nameWithoutExtension.endsWith(preprocessSuffix)) {
             val actualFileNameSize = file.nameWithoutExtension.length - preprocessSuffix.length
             file.parentFile.resolve("${file.nameWithoutExtension.take(actualFileNameSize)}.${file.extension}")
         } else file
-        return CppFuzzyParsingResult(actualFile)
+        return CppFuzzyParsingResult(actualFile, inputDirectoryPath)
     }
 
     /**
@@ -29,7 +29,7 @@ object FuzzyParsingResultFactory : PreprocessingParsingResultFactory {
         return outputFile
     }
 
-    class CppFuzzyParsingResult(file: File) : ParsingResult<FuzzyNode>(file) {
+    class CppFuzzyParsingResult(file: File, inputDirectoryPath: String?) : ParsingResult<FuzzyNode>(file, inputDirectoryPath) {
         override val root = FuzzyCppParser().parseFile(file)
         override val splitter = FuzzyFunctionSplitter()
     }

--- a/src/main/kotlin/astminer/parse/fuzzy/FuzzyParsingResultFactory.kt
+++ b/src/main/kotlin/astminer/parse/fuzzy/FuzzyParsingResultFactory.kt
@@ -29,7 +29,10 @@ object FuzzyParsingResultFactory : PreprocessingParsingResultFactory {
         return outputFile
     }
 
-    class CppFuzzyParsingResult(file: File, inputDirectoryPath: String?) : ParsingResult<FuzzyNode>(file, inputDirectoryPath) {
+    class CppFuzzyParsingResult(file: File, inputDirectoryPath: String?) : ParsingResult<FuzzyNode>(
+        file,
+        inputDirectoryPath
+    ) {
         override val root = FuzzyCppParser().parseFile(file)
         override val splitter = FuzzyFunctionSplitter()
     }

--- a/src/main/kotlin/astminer/parse/gumtree/GumtreeParsingResult.kt
+++ b/src/main/kotlin/astminer/parse/gumtree/GumtreeParsingResult.kt
@@ -13,27 +13,33 @@ import astminer.parse.gumtree.python.GumTreePythonParser
 import java.io.File
 
 object GumtreeJavaJDTParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File): ParsingResult<GumTreeNode> = GumTreeJavaJDTParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        GumTreeJavaJDTParsingResult(file, inputDirectoryPath)
 
-    class GumTreeJavaJDTParsingResult(file: File) : ParsingResult<GumTreeNode>(file) {
+    class GumTreeJavaJDTParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<GumTreeNode>(file, inputDirectoryPath) {
         override val root = GumTreeJavaJDTParser().parseFile(file)
         override val splitter = GumTreeJavaJDTFunctionSplitter()
     }
 }
 
 object GumtreeJavaSrcmlParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File): ParsingResult<out Node> = GumTreeJavaSrcmlParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        GumTreeJavaSrcmlParsingResult(file, inputDirectoryPath)
 
-    class GumTreeJavaSrcmlParsingResult(file: File) : ParsingResult<GumTreeNode>(file) {
+    class GumTreeJavaSrcmlParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<GumTreeNode>(file, inputDirectoryPath) {
         override val root: GumTreeNode = GumTreeJavaSrcmlParser().parseFile(file)
         override val splitter: TreeFunctionSplitter<GumTreeNode> = GumTreeJavaSrcmlFunctionSplitter()
     }
 }
 
 object GumtreePythonParsingResultFactory : ParsingResultFactory {
-    override fun parse(file: File): ParsingResult<GumTreeNode> = PythonGumtreeParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?) =
+        PythonGumtreeParsingResult(file, inputDirectoryPath)
 
-    class PythonGumtreeParsingResult(file: File) : ParsingResult<GumTreeNode>(file) {
+    class PythonGumtreeParsingResult(file: File, inputDirectoryPath: String?) :
+        ParsingResult<GumTreeNode>(file, inputDirectoryPath) {
         override val root = GumTreePythonParser().parseFile(file)
         override val splitter = GumTreePythonFunctionSplitter()
     }

--- a/src/main/kotlin/astminer/parse/gumtree/GumtreeParsingResult.kt
+++ b/src/main/kotlin/astminer/parse/gumtree/GumtreeParsingResult.kt
@@ -1,6 +1,5 @@
 package astminer.parse.gumtree
 
-import astminer.common.model.Node
 import astminer.common.model.ParsingResult
 import astminer.common.model.ParsingResultFactory
 import astminer.common.model.TreeFunctionSplitter

--- a/src/main/kotlin/astminer/parse/javaparser/JavaParserParsingResult.kt
+++ b/src/main/kotlin/astminer/parse/javaparser/JavaParserParsingResult.kt
@@ -3,11 +3,13 @@ package astminer.parse.javaparser
 import astminer.common.model.*
 import java.io.File
 
-class JavaParserParsingResult(file: File) : ParsingResult<JavaParserNode>(file) {
+class JavaParserParsingResult(file: File, inputDirectoryPath: String?) :
+    ParsingResult<JavaParserNode>(file, inputDirectoryPath) {
     override val root: JavaParserNode = JavaParserParseWrapper().parseFile(file)
     override val splitter: TreeFunctionSplitter<JavaParserNode> = JavaparserMethodSplitter()
 }
 
 object JavaParserParsedFileFactory : ParsingResultFactory {
-    override fun parse(file: File): ParsingResult<out Node> = JavaParserParsingResult(file)
+    override fun parse(file: File, inputDirectoryPath: String?): ParsingResult<out Node> =
+        JavaParserParsingResult(file, inputDirectoryPath)
 }

--- a/src/main/kotlin/astminer/pipeline/Pipeline.kt
+++ b/src/main/kotlin/astminer/pipeline/Pipeline.kt
@@ -49,12 +49,8 @@ class Pipeline(private val config: PipelineConfig) {
                 val holdoutFiles = getProjectFilesWithExtension(holdoutDir, language.fileExtension)
                 printHoldoutStat(holdoutFiles, holdoutType)
                 val progressBar = ProgressBar("", holdoutFiles.size.toLong())
-                parsingResultFactory.parseFilesInThreads(
-                    holdoutFiles,
-                    config.numOfThreads,
-                    inputDirectory.path
-                ) { parseResult ->
-                    val labeledResults = branch.process(parseResult)
+                parsingResultFactory.parseFilesInThreads(holdoutFiles, config.numOfThreads, inputDirectory.path) {
+                    val labeledResults = branch.process(it)
                     storage.storeSynchronously(labeledResults, holdoutType)
                     progressBar.step()
                 }

--- a/src/main/kotlin/astminer/pipeline/Pipeline.kt
+++ b/src/main/kotlin/astminer/pipeline/Pipeline.kt
@@ -49,7 +49,11 @@ class Pipeline(private val config: PipelineConfig) {
                 val holdoutFiles = getProjectFilesWithExtension(holdoutDir, language.fileExtension)
                 printHoldoutStat(holdoutFiles, holdoutType)
                 val progressBar = ProgressBar("", holdoutFiles.size.toLong())
-                parsingResultFactory.parseFilesInThreads(holdoutFiles, config.numOfThreads) { parseResult ->
+                parsingResultFactory.parseFilesInThreads(
+                    holdoutFiles,
+                    config.numOfThreads,
+                    inputDirectory.path
+                ) { parseResult ->
                     val labeledResults = branch.process(parseResult)
                     storage.storeSynchronously(labeledResults, holdoutType)
                     progressBar.step()

--- a/src/test/kotlin/astminer/common/DummyNode.kt
+++ b/src/test/kotlin/astminer/common/DummyNode.kt
@@ -24,7 +24,7 @@ class DummyNode(
     fun labeledWith(label: String) = LabeledResult(this, label, "")
 }
 
-class DummyParsingResult(file: File, override val root: DummyNode) : ParsingResult<DummyNode>(file) {
+class DummyParsingResult(file: File, override val root: DummyNode) : ParsingResult<DummyNode>(file, file.path) {
     override val splitter: TreeFunctionSplitter<DummyNode> = object : TreeFunctionSplitter<DummyNode> {
         override fun splitIntoFunctions(root: DummyNode, filePath: String) = listOf<FunctionInfo<DummyNode>>()
     }


### PR DESCRIPTION
Every parsing result is working in the same `inputDir`, so it's better to use relative paths instead of absolute ones