### PR TITLE
JavaParser annotations fix

### DIFF
--- a/src/main/kotlin/astminer/parse/javaparser/JavaParserNode.kt
+++ b/src/main/kotlin/astminer/parse/javaparser/JavaParserNode.kt
@@ -3,6 +3,7 @@ package astminer.parse.javaparser
 import astminer.common.model.Node
 import com.github.javaparser.ast.expr.AssignExpr
 import com.github.javaparser.ast.expr.BinaryExpr
+import com.github.javaparser.ast.expr.Name
 import com.github.javaparser.ast.expr.UnaryExpr
 import mu.KotlinLogging
 import com.github.javaparser.ast.Node as JPNode
@@ -64,6 +65,9 @@ private fun JPNode.isLeaf(): Boolean = this.childNodes.isEmpty()
 private fun JPNode.hasNoToken(): Boolean = !this.tokenRange.isPresent
 
 private fun getJavaParserNodeToken(jpNode: JPNode): String? {
-    if (jpNode.childNodes.isNotEmpty()) return null
-    return jpNode.tokenRange.get().toString()
+    return when {
+        jpNode is Name -> jpNode.asString()
+        jpNode.isLeaf() -> jpNode.tokenRange.get().toString()
+        else -> null
+    }
 }

--- a/src/main/kotlin/astminer/parse/javaparser/JavaparserFunctionInfo.kt
+++ b/src/main/kotlin/astminer/parse/javaparser/JavaparserFunctionInfo.kt
@@ -38,7 +38,7 @@ class JavaparserFunctionInfo(override val root: JavaParserNode, override val fil
 
     override val annotations: List<String>? = run {
         root.children.filter { it.typeLabel in POSSIBLE_ANNOTATION_TYPES }.map {
-            val token = it.getChildOfType(ANNOTATION_NAME)?.originalToken
+            val token = it.getChildOfType(ANNOTATION_NAME)?.originalToken?.split(".")?.last()
             if (token == null) {
                 logger.warn { "Annotation for function $name in file $filePath doesn't have a token" }
                 return@run null


### PR DESCRIPTION
Add support to parser annotations with package names. For example:
`@org.aspectj.lang.annotation.Before("execution(* scheduled())")`