### PR TITLE
Fix property name in python yaml config

### DIFF
--- a/configs/antlr_python_paths.yaml
+++ b/configs/antlr_python_paths.yaml
@@ -21,5 +21,5 @@ label:
 # save paths in code2vec format
 storage:
   name: code2seq
-  maxPathLength: 9
-  maxPathWidth: 2
+  length: 9
+  width: 2


### PR DESCRIPTION
Fixing path and width unknown error
com.charleskorn.kaml.UnknownPropertyException at storage.maxPathWidth on line 25, column 3: Unknown property 'maxPathWidth'. Known properties are: length, maxPathContextsPerEntity, nodesToNumber, width